### PR TITLE
Support guessing name of packages in non-traditional path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
+### Upcoming
+
+* Supports guessing names of packages outside of main root
+
 ### 3.0.5
 
 * Replace Linux-specific dependency `callsite` with cross-platform `sb-callsite`
 
 ### 3.0.4
 
-* Fix a scenario when error would be thrown if package name guessign fails
+* Fix a scenario when error would be thrown if package name guessing fails
 
 ### 3.0.3
 
@@ -38,7 +42,7 @@
 
 ### 2.1.0
 
-* Introduced second parameter to install method 
+* Introduced second parameter to install method
 
 ### 2.0.x
 

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -2,11 +2,28 @@
 
 import {BufferedProcess} from 'atom'
 const extractionRegex = /Installing (.*?) to .* (.*)/
-const nameRegex = /(\\|\/)packages(\\|\/)(.*?)(\\|\/)/
+const nameRegexes = [
+  /(\\|\/)packages(\\|\/)(.*?)(\\|\/)/,
+  /(\\|\/)([\w-_]+)(\\|\/)(lib|src)(\\|\/)/i,
+  /(\\|\/)([\w-_]+)(\\|\/)[\w-_]+\..+$/
+]
 
 export function guessName(filePath) {
-  const matches = nameRegex.exec(filePath)
-  return matches ? matches[3] : null
+  let matches
+
+  matches = nameRegexes[0].exec(filePath)
+  if (matches) {
+    return matches[3]
+  }
+  matches = nameRegexes[1].exec(filePath)
+  if (matches) {
+    return matches[2]
+  }
+  matches = nameRegexes[2].exec(filePath)
+  if (matches) {
+    return matches[2]
+  }
+  return null
 }
 
 export function installPackages(dependencies, progressCallback) {

--- a/package.json
+++ b/package.json
@@ -19,9 +19,6 @@
     "url": "https://github.com/AtomLinter/package-deps/issues"
   },
   "homepage": "https://github.com/AtomLinter/package-deps#readme",
-  "devDependencies": {
-    "event-kit": "^1.3.0"
-  },
   "dependencies": {
     "sb-callsite": "^1.0.0"
   }

--- a/spec/package-deps-spec.coffee
+++ b/spec/package-deps-spec.coffee
@@ -94,7 +94,14 @@ describe 'Package-Deps', ->
     describe 'guessName', ->
       Helpers = require('../lib/helpers')
 
-      it 'works for nix', ->
+      it 'works for packages in the correct place', ->
         expect(Helpers.guessName('/home/steel/.atom/packages/linter/lib/main.js')).toBe('linter')
-      it 'works for windows', ->
-        expect(Helpers.guessName('C:\\Users\\Anees Iqbal\\.atom\\packages\\linter\\lib\\main.js')).toBe('linter')
+        expect(Helpers.guessName('C:\\Users\\Steel Brain\\.atom\\packages\\linter\\lib\\main.js')).toBe('linter')
+
+      it 'works for packages that use the lib or src folder', ->
+        expect(Helpers.guessName('/home/steel/github/linter/lib/main.js')).toBe('linter')
+        expect(Helpers.guessName('C:\\Users\\Steel Brain\\github\\linter\\lib\\main.js')).toBe('linter')
+
+      it 'works for packages that have the main file in root folder', ->
+        expect(Helpers.guessName('/home/steel/github/linter/main.js')).toBe('linter')
+        expect(Helpers.guessName('C:\\Users\\Steel Brain\\github\\linter\\main.js')).toBe('linter')


### PR DESCRIPTION
As reported by @Arcanemagus and @joefitzgerald :bow:

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/steelbrain/package-deps/32)
<!-- Reviewable:end -->
