### PR TITLE
Simplify the regex used

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -3,9 +3,9 @@
 import {BufferedProcess} from 'atom'
 const extractionRegex = /Installing (.*?) to .* (.*)/
 const nameRegexes = [
-  /(\\|\/)packages(\\|\/)(.*?)(\\|\/)/,
-  /(\\|\/)([\w-_]+)(\\|\/)(lib|src)(\\|\/)/i,
-  /(\\|\/)([\w-_]+)(\\|\/)[\w-_]+\..+$/
+  /[\\\/]packages[\\\/](.*?)[\\\/]/,
+  /[\\\/]([\w-_]+)[\\\/](?:lib|src)[\\\/]/i,
+  /[\\\/]([\w-_]+)[\\\/][\w-_]+\..+$/
 ]
 
 export function guessName(filePath) {
@@ -13,15 +13,15 @@ export function guessName(filePath) {
 
   matches = nameRegexes[0].exec(filePath)
   if (matches) {
-    return matches[3]
+    return matches[1]
   }
   matches = nameRegexes[1].exec(filePath)
   if (matches) {
-    return matches[2]
+    return matches[1]
   }
   matches = nameRegexes[2].exec(filePath)
   if (matches) {
-    return matches[2]
+    return matches[1]
   }
   return null
 }


### PR DESCRIPTION
It doesn't matter which path separator is used, no need to save it in a capturing group.

This makes the execution quite a bit simpler according to the information on regex101.com:

0. [842 steps](https://regex101.com/r/qO1bS4/1) to [314 steps](https://regex101.com/r/qO1bS4/2)
0. [1021 steps](https://regex101.com/r/hM7yZ9/1) to [444 steps](https://regex101.com/r/hM7yZ9/3)
0. [1076 steps](https://regex101.com/r/eW4oK1/1) to [453 steps](https://regex101.com/r/eW4oK1/2)

_Note: The regex are set to use `pcre` on regex101.com so we can see the execution complexity, but switching to javascript returns the same results._