### PR TITLE
Unquash first errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atom-package-deps",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "Automatically install package dependencies",
   "main": "lib/index.js",
   "scripts": {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -21,8 +21,7 @@ export function spawnAPM(dependencies, progressCallback) {
         }
       },
       stderr: function(contents) {
-        const lastIndex = errors.length - 1
-        errors[lastIndex] += ': ' + contents
+        errors.push(contents)
       },
       exit: function() {
         if (errors.length) {


### PR DESCRIPTION
Sometimes the first output of a dependency install is an error message. This code was effectively hiding that output in this situation:
```javascript
        const lastIndex = errors.length - 1
        errors[lastIndex] += ': ' + contents
```

I've updated the version number to 4.0.2 in a separate commit.