### PR TITLE
Better error determination

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atom-package-deps",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "Automatically install package dependencies",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atom-package-deps",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "description": "Automatically install package dependencies",
   "main": "lib/index.js",
   "scripts": {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -21,8 +21,7 @@ export function spawnAPM(dependencies, progressCallback) {
         }
       },
       stderr: function(contents) {
-        const lastIndex = errors.length - 1
-        errors[lastIndex] += ': ' + contents
+        errors.push(contents)
       },
       exit: function() {
         if (errors.length) {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -14,7 +14,9 @@ export function spawnAPM(dependencies, progressCallback) {
       options: {},
       stdout: function(contents) {
         const matches = extractionRegex.exec(contents)
-        if (matches[2] === '✓' || matches[2] === 'done') {
+        if (!matches) {
+          // info messages: ignore
+        } else if (matches[2] === '✓' || matches[2] === 'done') {
           progressCallback(matches[1], true)
           successes++
         } else {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -7,6 +7,7 @@ const extractionRegex = /Installing (.*?) to .* (.*)/
 export function spawnAPM(dependencies, progressCallback) {
   return new Promise(function(resolve, reject) {
     const errors = []
+    let successes = 0
     new BufferedProcess({
       command: atom.packages.getApmPath(),
       args: ['install'].concat(dependencies).concat(['--production', '--color', 'false']),
@@ -15,6 +16,7 @@ export function spawnAPM(dependencies, progressCallback) {
         const matches = extractionRegex.exec(contents)
         if (matches[2] === '✓' || matches[2] === 'done') {
           progressCallback(matches[1], true)
+          successes++
         } else {
           progressCallback(matches[1], false)
           errors.push(matches[1])
@@ -24,7 +26,7 @@ export function spawnAPM(dependencies, progressCallback) {
         errors.push(contents)
       },
       exit: function() {
-        if (errors.length) {
+        if (successes !== dependencies.length) {
           const error = new Error('Error installing dependencies')
           error.stack = errors.join('\n')
           reject(error)


### PR DESCRIPTION
The success of a dependency install was being based on the presence of error messages, and apm info messages were inadvertently being treated as errors. This PR makes two changes:
- It specifically checks whether an install succeeded (based on the existing regexp check for "Installing ... to ..." followed by a checkmark or the word "done"), instead of inferring failure from error messages, and
- It allows for the presence of info messages (such as "Cloning ... to ...") without inferring failure/success from these.

I've updated the version number to 4.0.**_3_** in a separate commit.

Although this PR is based on #47, it can be applied separately (except for the version change).