### PR TITLE
handle apm messages for repo-based packages

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -2,7 +2,7 @@
 
 import {BufferedProcess} from 'atom'
 import {View} from './view'
-const extractionRegex = /Installing (.*?) to .* (.*)/
+const extractionRegex = /(?:Installing|Moving) (.*?) to .* (.*)/
 
 export function spawnAPM(dependencies, progressCallback) {
   return new Promise(function(resolve, reject) {


### PR DESCRIPTION
_package-deps_ seemed to be assuming that dependencies would always be "standard" Atom packages from _atom.io_, and so mishandled "repo" packages (from GitHub or Bitbucket). PR #48 partially addresses this problem (by properly handling error messages), but this PR goes further by properly checking for the distinct success message that `apm` produces when installing repo packages ("Moving ... to ..." as the final step, instead of "Installing ... to ...").

Version number was not updated in this PR.