### PR TITLE
Install packages separately

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 *   Better track success of package installs
 *   Handle info message from apm during installs
 *   Handle packages installed from repositories
+*   Allow parallel installation of packages
 
 ## 4.0.1
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -5,37 +5,39 @@ import {View} from './view'
 const extractionRegex = /(?:Installing|Moving) (.*?) to .* (.*)/
 
 export function spawnAPM(dependencies, progressCallback) {
-  return new Promise(function(resolve, reject) {
-    const errors = []
-    let successes = 0
-    new BufferedProcess({
-      command: atom.packages.getApmPath(),
-      args: ['install'].concat(dependencies).concat(['--production', '--color', 'false']),
-      options: {},
-      stdout: function(contents) {
-        const matches = extractionRegex.exec(contents)
-        if (!matches) {
-          // info messages: ignore
-        } else if (matches[2] === '✓' || matches[2] === 'done') {
-          progressCallback(matches[1], true)
-          successes++
-        } else {
-          progressCallback(matches[1], false)
-          errors.push(matches[1])
+  return Promise.all(dependencies.map(function(dependency) {
+    return new Promise(function(resolve, reject) {
+      const errors = []
+      let successes = 0
+      new BufferedProcess({
+        command: atom.packages.getApmPath(),
+        args: ['install'].concat([dependency, '--production', '--color', 'false']),
+        options: {},
+        stdout: function(contents) {
+          const matches = extractionRegex.exec(contents)
+          if (!matches) {
+            // info messages: ignore
+          } else if (matches[2] === '✓' || matches[2] === 'done') {
+            progressCallback(matches[1], true)
+            successes++
+          } else {
+            progressCallback(matches[1], false)
+            errors.push(matches[1])
+          }
+        },
+        stderr: function(contents) {
+          errors.push(contents)
+        },
+        exit: function() {
+          if (successes !== dependencies.length) {
+            const error = new Error('Error installing dependency: ' + dependency)
+            error.stack = errors.join('\n')
+            reject(error)
+          } else resolve()
         }
-      },
-      stderr: function(contents) {
-        errors.push(contents)
-      },
-      exit: function() {
-        if (successes !== dependencies.length) {
-          const error = new Error('Error installing dependencies')
-          error.stack = errors.join('\n')
-          reject(error)
-        } else resolve()
-      }
+      })
     })
-  })
+  }))
 }
 
 export async function installDependencies(name, packages) {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -8,7 +8,7 @@ export function spawnAPM(dependencies, progressCallback) {
   return Promise.all(dependencies.map(function(dependency) {
     return new Promise(function(resolve, reject) {
       const errors = []
-      let successes = 0
+      let success = false
       new BufferedProcess({
         command: atom.packages.getApmPath(),
         args: ['install'].concat([dependency, '--production', '--color', 'false']),
@@ -19,7 +19,7 @@ export function spawnAPM(dependencies, progressCallback) {
             // info messages: ignore
           } else if (matches[2] === '✓' || matches[2] === 'done') {
             progressCallback(matches[1], true)
-            successes++
+            success = true
           } else {
             progressCallback(matches[1], false)
             errors.push(matches[1])
@@ -29,7 +29,7 @@ export function spawnAPM(dependencies, progressCallback) {
           errors.push(contents)
         },
         exit: function() {
-          if (successes !== dependencies.length) {
+          if (!success) {
             const error = new Error('Error installing dependency: ' + dependency)
             error.stack = errors.join('\n')
             reject(error)


### PR DESCRIPTION
Last one!

This PR is a little weird. The reason for it is to work around [apm issue 580](https://github.com/atom/apm/issues/580), which has been sitting unfixed for 7+ weeks. It does this by installing each dependency in a separate BufferedProcess, instead of installing them all in one shot. In addition to handling issue 580, this also allows the package installs to be parallelized (is this better?) and returns errors more quickly (because the first error ends the `Promise.all()`) and with more specificity ("Error installing dependency: foo" instead of "Error installing dependencies").

Changelog is also updated in this PR.