### PR TITLE
Resolve named packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4.1.1
+
+*   Support git-based packages without repeatedly reinstalling
+
 ## 4.1.0
 
 *   Allow parallel installation of packages

--- a/README.md
+++ b/README.md
@@ -14,6 +14,21 @@ You need to have an array of package deps in your package manifest, like
 }
 ```
 
+If you need to install package deps from a git remote (in any format supported by `apm install`, use an object instead of a string:
+
+```js
+{
+  "name": "linter-ruby",
+  ...
+  "package-deps": [
+    {
+      "name: "linter",
+      "url" "steelbrain/linter"
+    }
+  ]
+}
+```
+
 Because the package installation is async, it returns a promise that resolves when all the dependencies have been installed.
 
 ```js

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ If you need to install package deps from a git remote (in any format supported b
   ...
   "package-deps": [
     {
-      "name: "linter",
-      "url" "steelbrain/linter"
+      "name": "linter",
+      "url": "steelbrain/linter"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atom-package-deps",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "Automatically install package dependencies",
   "main": "lib/index.js",
   "scripts": {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -45,12 +45,20 @@ export function getDependencies(packageName: string): Array<string> {
   const packageDependencies = packageModule && packageModule.metadata['package-deps']
 
   if (packageDependencies) {
-    for (const entry of (packageDependencies: Array<string>)) {
-      if (__steelbrain_package_deps.has(entry) || atom.packages.resolvePackagePath(entry)) {
+    for (const entry of (packageDependencies: Array<string | { name: string, url: string }>)) {
+      let entryName = entry
+      let entryUrl = entry
+
+      if (typeof entry === 'object') {
+        entryName = entry.name
+        entryUrl = entry.url
+      }
+
+      if (__steelbrain_package_deps.has(entryName) || atom.packages.resolvePackagePath(entryName)) {
         continue
       }
-      __steelbrain_package_deps.add(entry)
-      toReturn.push(entry)
+      __steelbrain_package_deps.add(entryName)
+      toReturn.push(entryUrl)
     }
   } else {
     console.error(`[Package-Deps] Unable to get loaded package '${packageName}'`)


### PR DESCRIPTION
This PR addresses issue #53 by expanding the format of the `package-deps` key (in _package.json_) to allow objects as well as strings:
```json
"package-deps": [
  "vanilla",
  "strawberry",
  {
    "name": "chocolate",
    "url": "githubuser/chocolate-chip"
  }
]
```

The `url` can be in any format supported by `apm install` (see `apm help install` for an incomplete list).

This PR also updates the README, CHANGELOG, and version.