### PR TITLE
Hotfix

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -82,7 +82,7 @@ export async function getDependencies(packageName: string): Promise<Array<Depend
 
 export async function promptUser(packageName: string, dependencies: Array<Dependency>): Promise<'Yes' | 'No' | 'Never'> {
   const oldConfigPath = Path.join(atom.getConfigDirPath(), 'package-deps-state.json')
-  let ignoredPackages = atom.config.get('atom-package-deps.ignored')
+  let ignoredPackages = atom.config.get('atom-package-deps.ignored') || []
 
   if (await FS.exists(oldConfigPath)) {
     const oldConfig = JSON.parse(await FS.readFile(oldConfigPath, 'utf8'))


### PR DESCRIPTION
`atom-package-deps` doesn't register a schema like all the other packages, so the default value is `undefined`. We were not handling to make it an array and it would fail on `.includes` below

Thankfully we haven't tagged a new release yet because we wanted to test and find any remaining bugs, which we did