### PR TITLE
Fix git installations support on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Upcoming
+
+- Remove `sb-exec` in favor of `BufferedProcess` from Atom builtins
+
 ## 4.6.0
 
 - Remove config file usage, configs are now stored in Atom config store

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   "homepage": "https://github.com/AtomLinter/package-deps#readme",
   "dependencies": {
     "atom-package-path": "^1.1.0",
-    "sb-exec": "^4.0.0",
     "sb-fs": "^3.0.0",
     "semver": "^5.3.0"
   },

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -10,7 +10,7 @@ let shownStorageInfo = false
 const VALID_TICKS = new Set(['✓', 'done'])
 const VALIDATION_REGEXP = /(?:Installing|Moving) (.*?) to .* (.*)/
 
-export function exec(command: string, parameters: Array<string>): Promise<{ stdout: string, stderr: string }> {
+function exec(command: string, parameters: Array<string>): Promise<{ stdout: string, stderr: string }> {
   return new Promise(function(resolve) {
     const data = { stdout: [], stderr: [] }
     const spawnedProcess = new BufferedProcess({

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -13,7 +13,7 @@ const VALIDATION_REGEXP = /(?:Installing|Moving) (.*?) to .* (.*)/
 export function exec(command: string, parameters: Array<string>): Promise<{ stdout: string, stderr: string }> {
   return new Promise(function(resolve) {
     const data = { stdout: [], stderr: [] }
-    const spawnedProcess = BufferedProcess({
+    const spawnedProcess = new BufferedProcess({
       command,
       args: parameters,
       stdout(chunk) {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -3,30 +3,50 @@
 import FS from 'sb-fs'
 import Path from 'path'
 import semver from 'semver'
-import { exec } from 'sb-exec'
+import { BufferedProcess } from 'atom'
 import type { Dependency } from './types'
 
 let shownStorageInfo = false
 const VALID_TICKS = new Set(['✓', 'done'])
 const VALIDATION_REGEXP = /(?:Installing|Moving) (.*?) to .* (.*)/
 
+export function exec(command: string, parameters: Array<string>): Promise<{ stdout: string, stderr: string }> {
+  return new Promise(function(resolve) {
+    const data = { stdout: [], stderr: [] }
+    const spawnedProcess = BufferedProcess({
+      command,
+      args: parameters,
+      stdout(chunk) {
+        data.stdout.push(chunk)
+      },
+      stderr(chunk) {
+        data.stderr.push(chunk)
+      },
+      exit() {
+        resolve({ stdout: data.stdout.join(''), stderr: data.stderr.join('') })
+      },
+      autoStart: false,
+    })
+    spawnedProcess.start()
+  })
+}
+
 export function apmInstall(dependencies: Array<Dependency>, progressCallback: ((packageName: string, status: boolean) => void)): Promise<Map<string, Error>> {
   const errors = new Map()
   return Promise.all(dependencies.map(function(dep) {
-    return exec(atom.packages.getApmPath(), ['install', dep.version ? `${dep.url}@${dep.version}` : dep.url, '--production', '--color', 'false'], {
-      stream: 'both',
-      ignoreExitCode: true,
-    }).then(function(output) {
-      const successful = VALIDATION_REGEXP.test(output.stdout) && VALID_TICKS.has(VALIDATION_REGEXP.exec(output.stdout)[2])
-      progressCallback(dep.name, successful)
-      if (!successful) {
-        const error = new Error(`Error installing dependency: ${dep.name}`)
-        error.stack = output.stderr
-        throw error
-      }
-    }).catch(function(error) {
-      errors.set(dep.name, error)
-    })
+    return exec(atom.packages.getApmPath(), ['install', dep.version ? `${dep.url}@${dep.version}` : dep.url, '--production', '--color', 'false'])
+      .then(function(output) {
+        const successful = VALIDATION_REGEXP.test(output.stdout) && VALID_TICKS.has(VALIDATION_REGEXP.exec(output.stdout)[2])
+        progressCallback(dep.name, successful)
+        if (!successful) {
+          const error = new Error(`Error installing dependency: ${dep.name}`)
+          error.stack = output.stderr
+          throw error
+        }
+      })
+      .catch(function(error) {
+        errors.set(dep.name, error)
+      })
   })).then(function() {
     return errors
   })


### PR DESCRIPTION
By using Atom's built-in `BufferedProcess` instead of `sb-exec`.

Fixes #101.