### PR TITLE
only load `semverSatisfies` from `semver`

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -2,7 +2,7 @@
 
 import fs from 'sb-fs'
 import Path from 'path'
-import semver from 'semver'
+import semverSatisfies from 'semver/functions/satisfies'
 import { BufferedProcess } from 'atom'
 import type { Dependency } from './types'
 
@@ -99,7 +99,7 @@ export async function getDependencies(packageName: string): Promise<Array<Depend
 
         const manifest = JSON.parse(await fs.readFile(Path.join(resolvedPath, 'package.json')))
         // $FlowIgnore: Flow is paranoid, this parsed.version is NOT NULL
-        if (semver.satisfies(manifest.version, `>=${version}`)) {
+        if (semverSatisfies(manifest.version, `>=${version}`)) {
           return null
         }
       }


### PR DESCRIPTION
This reduces the loading time of `package-deps` by only loading the needed function from `semver`

This is mentioned in https://github.com/npm/node-semver#usage too.

Tested with `atom-ide-datatips`, and it works as expected.