### PR TITLE
Set patch-package as (normal) dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,9 @@
     "url": "https://github.com/AtomLinter/package-deps/issues"
   },
   "homepage": "https://github.com/AtomLinter/package-deps#readme",
-  "dependencies": {},
+  "dependencies": {
+    "patch-package": "^6.2.2"
+  },
   "devDependencies": {
     "@babel/core": "^7.11.1",
     "@babel/preset-env": "^7.11.0",
@@ -43,7 +45,6 @@
     "eslint-config-steelbrain": "^10.0.0-beta2",
     "p-filter": "^2.1.0",
     "p-map": "^4.0.0",
-    "patch-package": "^6.2.2",
     "rollup": "^2.26.2",
     "rollup-plugin-preserve-shebang": "^1.0.1",
     "semver-compare": "^1.0.0",


### PR DESCRIPTION
Closes #317 by setting the `patch-package` package as a normal dependency instead of a devDependency so that it will always be available in the context of the `"postinstall"` script (if I'm not mistaken).