### PR TITLE
fix: don't ignore when notifications-plus is installed

### DIFF
--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -109,12 +109,6 @@ export function isPackageIgnored(name: string): boolean {
     return true
   }
 
-  // If Atom "notifications" package is disabled, treat the whole thing as ignored
-  if (atom.packages.isPackageDisabled('notifications')) {
-    console.warn(`Enable notifications to install dependencies for ${name}`)
-    return true
-  }
-
   return false
 }
 

--- a/src/view/atom.ts
+++ b/src/view/atom.ts
@@ -21,7 +21,7 @@ export function confirmPackagesToInstall({
       : 'Something went wrong. Check your developer console'
     const groupChoices = groupedDependencies.map((item) => item[0])
 
-    // If Atom "notifications" package is disabled, treat the whole thing as ignored
+    // If Atom "notifications" package is disabled output a warning in case no other notifications package is installed.
     if (atom.packages.isPackageDisabled('notifications')) {
       console.warn(`Enable notifications to install dependencies for ${packageName}`)
     }

--- a/src/view/atom.ts
+++ b/src/view/atom.ts
@@ -21,6 +21,10 @@ export function confirmPackagesToInstall({
       : 'Something went wrong. Check your developer console'
     const groupChoices = groupedDependencies.map((item) => item[0])
 
+    // If Atom "notifications" package is disabled, treat the whole thing as ignored
+    if (atom.packages.isPackageDisabled('notifications')) {
+      console.warn(`Enable notifications to install dependencies for ${packageName}`)
+    }
     const notification = atom.notifications.addInfo(`${packageName} needs to install dependencies`, {
       dismissable: true,
       icon: 'cloud-download',


### PR DESCRIPTION
Don't ignore all packages if [notifications-plus](https://atom.io/packages/notifications-plus) is installed and notifications package is disabled.

Just because the notifications package is disabled does not mean they don't get notifications.