### PR TITLE
Wrap the apm command in quotes in case it has spaces.

### DIFF
--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -128,7 +128,7 @@ const INSTALL_VALIDATION_REGEXP = /(?:Installing|Moving) (.*?) to .* (.*)/
 export async function installPackage(dependency: DependencyResolved): Promise<void> {
   const apmPath = IS_ATOM ? atom.packages.getApmPath() : 'apm'
 
-  const { stdout, stderr } = await spawn(apmPath, ['install', dependency.name, '--production', '--color', 'false'], {
+  const { stdout, stderr } = await spawn(`"${apmPath}"`, ['install', dependency.name, '--production', '--color', 'false'], {
     shell: true,
   })
 


### PR DESCRIPTION
Fixes #330, as documented in [Node.](https://nodejs.org/api/child_process.html#child_process_spawning_bat_and_cmd_files_on_windows)

Works on both my Windows and Mac machines, both with commands and paths to executables.