### PR TITLE
fix: ungrouped dependencies were never installed

### DIFF
--- a/src/view/atom.ts
+++ b/src/view/atom.ts
@@ -35,7 +35,7 @@ export function confirmPackagesToInstall({
           text: 'Yes',
           onDidClick: () => {
             if (skipGroups) {
-              resolve([])
+              resolve(ungroupedDependencies)
             } else {
               resolve(ungroupedDependencies.concat(groupChoices))
             }


### PR DESCRIPTION
This was discussed on the Atom-community discord. Long story short, `confirmPackagesToInstall` returns an empty array instead of the list of dependencies if there are no dependency groups.