### PR TITLE
Use atom.getConfigDirPath

### DIFF
--- a/src/helpers/node.ts
+++ b/src/helpers/node.ts
@@ -1,6 +1,7 @@
 import fs from 'fs'
 import os from 'os'
 import path from 'path'
+import type { AtomEnvironment } from 'atom' // eslint-disable-line import/no-unresolved
 import { Dependency, DependencyResolved } from '../types'
 
 export async function getDependencies(packageName: string): Promise<(Dependency | Dependency[])[]> {
@@ -45,7 +46,7 @@ export async function resolveDependencyPath(packageName: string): Promise<string
  * so we need to install packages in the correct path
  */
 function getAtomHomePath() {
-  return atom.getConfigDirPath() ?? process.env.ATOM_HOME ?? path.join(os.homedir(), '.atom')
+  return (atom as AtomEnvironment | null)?.getConfigDirPath() ?? process.env.ATOM_HOME ?? path.join(os.homedir(), '.atom')
 }
 
 export async function getInstalledDependencyVersion(dependency: DependencyResolved): Promise<string | null> {

--- a/src/helpers/node.ts
+++ b/src/helpers/node.ts
@@ -1,8 +1,8 @@
 import fs from 'fs'
 import os from 'os'
 import path from 'path'
-import type { AtomEnvironment } from 'atom' // eslint-disable-line import/no-unresolved
 import { Dependency, DependencyResolved } from '../types'
+import { IS_ATOM } from '../constants'
 
 export async function getDependencies(packageName: string): Promise<(Dependency | Dependency[])[]> {
   let packageStats: fs.Stats | null = null
@@ -46,7 +46,7 @@ export async function resolveDependencyPath(packageName: string): Promise<string
  * so we need to install packages in the correct path
  */
 function getAtomHomePath() {
-  return (atom as AtomEnvironment | null)?.getConfigDirPath() ?? process.env.ATOM_HOME ?? path.join(os.homedir(), '.atom')
+  return IS_ATOM ? atom.getConfigDirPath() : process.env.ATOM_HOME ?? path.join(os.homedir(), '.atom')
 }
 
 export async function getInstalledDependencyVersion(dependency: DependencyResolved): Promise<string | null> {

--- a/src/helpers/node.ts
+++ b/src/helpers/node.ts
@@ -29,7 +29,7 @@ export async function getDependencies(packageName: string): Promise<(Dependency 
 }
 
 export async function resolveDependencyPath(packageName: string): Promise<string | null> {
-  const packageDirectory = path.join(process.env.ATOM_HOME ?? path.join(os.homedir(), '.atom'), 'packages', packageName)
+  const packageDirectory = path.join(getAtomHomePath(), 'packages', packageName)
 
   try {
     await fs.promises.access(packageDirectory, fs.constants.R_OK)
@@ -37,6 +37,15 @@ export async function resolveDependencyPath(packageName: string): Promise<string
   } catch (_) {
     return null
   }
+}
+
+/**
+ * Get the atom home which includes `packages` folder.
+ * Test runners such as `atom-jasmine3-runner` change this folder in the test env,
+ * so we need to install packages in the correct path
+ */
+function getAtomHomePath() {
+  return atom.getConfigDirPath() ?? process.env.ATOM_HOME ?? path.join(os.homedir(), '.atom')
 }
 
 export async function getInstalledDependencyVersion(dependency: DependencyResolved): Promise<string | null> {


### PR DESCRIPTION
Get the atom home which includes the `packages` folder. Test runners such as `atom-jasmine3-runner` change this folder in the test env, so we need to install packages in the correct path.


